### PR TITLE
Backport DBZ-8194 and DBZ-8340 to 0.31.x

### DIFF
--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -347,13 +347,13 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
         if ( gtidStr == null )
             return;
 
-        this.gtidEnabled = true;
-
-        if (this.binlogFilename == null) {
-            this.binlogFilename = "";
-        }
-
         synchronized (gtidSetAccessLock) {
+            this.gtidEnabled = true;
+
+            if (this.binlogFilename == null) {
+                this.binlogFilename = "";
+            }
+
             if ( !gtidStr.equals("") ) {
                 if ( MariadbGtidSet.isMariaGtidSet(gtidStr) ) {
                     this.gtidSet = new MariadbGtidSet(gtidStr);
@@ -1000,10 +1000,10 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
     }
 
     protected void setupGtidSet() throws IOException{
-        if (!this.gtidEnabled)
-            return;
-
         synchronized (gtidSetAccessLock) {
+            if (!this.gtidEnabled)
+                return;
+
             if ( this.databaseVersion.isMariaDb() ) {
                 if ( gtidSet == null ) {
                     gtidSet = new MariadbGtidSet("");

--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -1193,6 +1193,9 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
                 MariadbGtidListEventData mariadbGtidListEventData = (MariadbGtidListEventData) EventDeserializer.EventDataWrapper.internal(event.getData());
                 gtid = mariadbGtidListEventData.getMariaGTIDSet().toString();
                 break;
+            case TRANSACTION_PAYLOAD:
+                commitGtid();
+                break;
             default:
         }
     }

--- a/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientBinlogCompressIntegrationTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientBinlogCompressIntegrationTest.java
@@ -1,0 +1,100 @@
+package com.github.shyiko.mysql.binlog;
+
+import org.testng.SkipException;
+import org.testng.annotations.Test;
+
+/**
+ * @author vjuranek
+ */
+public class BinaryLogClientBinlogCompressIntegrationTest extends BinaryLogClientGTIDIntegrationTest {
+    @Override
+    protected MysqlOnetimeServerOptions getOptions() {
+        if ( !this.mysqlVersion.atLeast(8,0) )  {
+            throw new SkipException("skipping binlog compression on 5.x");
+        }
+
+        MysqlOnetimeServerOptions options = new MysqlOnetimeServerOptions();
+        options.gtid = true;
+        options.extraParams = "--binlog_transaction_compression=ON";
+        return options;
+    }
+
+    // These tests fail when binlog compression is enabled because the columns of these types are
+    // serialized in a plain text representation when the records are uncompressed.
+
+    @Test
+    @Override
+    public void testDeserializationOfDATE() throws Exception {
+        throw new SkipException("Skipped due to binlog compression");
+    }
+
+    @Test
+    @Override
+    public void testDeserializationOfDATETIME() throws Exception {
+        throw new SkipException("Skipped due to binlog compression");
+    }
+
+    @Test
+    @Override
+    public void testDeserializationOfDateAndTimeAsLong() throws Exception {
+        throw new SkipException("Skipped due to binlog compression");
+    }
+
+    @Test
+    @Override
+    public void testDeserializationOfDateAndTimeAsLongMicrosecondsPrecision() throws Exception {
+        throw new SkipException("Skipped due to binlog compression");
+    }
+
+    @Test
+    @Override
+    public void testDeserializationOfSTRING() throws Exception {
+        throw new SkipException("Skipped due to binlog compression");
+    }
+
+    @Test
+    @Override
+    public void testDeserializationOfTIME() throws Exception {
+        throw new SkipException("Skipped due to binlog compression");
+    }
+
+    @Test
+    @Override
+    public void testDeserializationOfTIMESTAMP() throws Exception {
+        throw new SkipException("Skipped due to binlog compression");
+    }
+
+    @Test
+    @Override
+    public void testDeserializationOfVARSTRING() throws Exception {
+        throw new SkipException("Skipped due to binlog compression");
+    }
+
+    @Test
+    @Override
+    public void testFSP() throws Exception {
+        throw new SkipException("Skipped due to binlog compression");
+    }
+
+    @Test
+    @Override
+    public void testWriteUpdateDeleteEvents() throws Exception {
+        throw new SkipException("Skipped due to binlog compression");
+    }
+
+    // This test tests custom deserializer which and assumes ordinary binlog,
+    // it can be skipped in this testsuite.
+    @Test
+    @Override
+    public void testCustomEventDataDeserializers() throws Exception {
+        throw new SkipException("Skipped due to binlog compression");
+    }
+
+    // This test tests switch to specific position in events and checks number of WriteRowsEventData events.
+    // In case of compressed binlog we are not able to switch in the middle of the TX.
+    @Test
+    @Override
+    public void testBinlogPositionPointsToTableMapEventUntilTheEndOfLogicalGroup() throws Exception {
+        throw new SkipException("Skipped due to binlog compression");
+    }
+}

--- a/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientGTIDIntegrationTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientGTIDIntegrationTest.java
@@ -65,6 +65,7 @@ public class BinaryLogClientGTIDIntegrationTest extends BinaryLogClientIntegrati
         master.execute("CREATE TABLE if not exists foo (i int)");
 
         String initialGTIDSet = getExecutedGtidSet(master);
+        assertNotNull("Initial GTID set is null", initialGTIDSet);
 
         EventDeserializer eventDeserializer = new EventDeserializer();
         try {
@@ -90,6 +91,7 @@ public class BinaryLogClientGTIDIntegrationTest extends BinaryLogClientIntegrati
                 eventListener.waitFor(XidEventData.class, 1, TimeUnit.SECONDS.toMillis(4));
                 String gtidSet = clientWithKeepAlive.getGtidSet();
                 assertNotNull(gtidSet);
+                assertNotEquals(initialGTIDSet, gtidSet, "Initial GTID set and current GTID set are the same");
 
                 eventListener.reset();
 
@@ -102,14 +104,14 @@ public class BinaryLogClientGTIDIntegrationTest extends BinaryLogClientIntegrati
                 });
 
                 eventListener.waitFor(XidEventData.class, 1, TimeUnit.SECONDS.toMillis(4));
-                assertNotEquals(client.getGtidSet(), gtidSet);
+                assertNotEquals(clientWithKeepAlive.getGtidSet(), gtidSet, "GTID set before and after INSERT operation are the same");
 
-                gtidSet = client.getGtidSet();
+                gtidSet = clientWithKeepAlive.getGtidSet();
 
                 eventListener.reset();
                 master.execute("DROP TABLE IF EXISTS test.bar");
                 eventListener.waitFor(QueryEventData.class, 1, TimeUnit.SECONDS.toMillis(4));
-                assertNotEquals(clientWithKeepAlive.getGtidSet(), gtidSet);
+                assertNotEquals(clientWithKeepAlive.getGtidSet(), gtidSet, "GTID set before and after DROP TABLE operation are the same");
             } finally {
                 clientWithKeepAlive.disconnect();
             }

--- a/src/test/java/com/github/shyiko/mysql/binlog/CapturingEventListener.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/CapturingEventListener.java
@@ -17,6 +17,8 @@ package com.github.shyiko.mysql.binlog;
 
 import com.github.shyiko.mysql.binlog.event.Event;
 import com.github.shyiko.mysql.binlog.event.EventData;
+import com.github.shyiko.mysql.binlog.event.EventType;
+import com.github.shyiko.mysql.binlog.event.TransactionPayloadEventData;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -32,7 +34,14 @@ public class CapturingEventListener extends CountDownEventListener {
     @Override
     public void onEvent(Event event) {
         synchronized (events) {
-            events.add(event);
+            if (event.getHeader().getEventType() == EventType.TRANSACTION_PAYLOAD) {
+                for (Event uncompressedEvent : ((TransactionPayloadEventData) event.getData()).getUncompressedEvents()) {
+                    events.add(uncompressedEvent);
+                }
+            }
+            else {
+                events.add(event);
+            }
             super.onEvent(event);
         }
     }

--- a/src/test/java/com/github/shyiko/mysql/binlog/CountDownEventListener.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/CountDownEventListener.java
@@ -18,6 +18,8 @@ package com.github.shyiko.mysql.binlog;
 import com.github.shyiko.mysql.binlog.event.Event;
 import com.github.shyiko.mysql.binlog.event.EventData;
 import com.github.shyiko.mysql.binlog.event.EventType;
+import com.github.shyiko.mysql.binlog.event.TransactionPayloadEventData;
+import com.github.shyiko.mysql.binlog.network.SSLMode;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,7 +40,16 @@ public class CountDownEventListener implements BinaryLogClient.EventListener {
         incrementCounter(getCounter(countersByType, event.getHeader().getEventType()));
         EventData data = event.getData();
         if (data != null) {
-            incrementCounter(getCounter(countersByDataClass, data.getClass()));
+            if (event.getHeader().getEventType() == EventType.TRANSACTION_PAYLOAD) {
+                for (Event uncompressedEvent : ((TransactionPayloadEventData) event.getData()).getUncompressedEvents()) {
+                    if (uncompressedEvent.getData() != null) {
+                        incrementCounter(getCounter(countersByDataClass, uncompressedEvent.getData().getClass()));
+                    }
+                }
+            }
+            else {
+                incrementCounter(getCounter(countersByDataClass, data.getClass()));
+            }
         }
     }
 


### PR DESCRIPTION
[DBZ-8194](https://issues.redhat.com/browse/DBZ-8194) and [DBZ-8340](https://issues.redhat.com/browse/DBZ-8340) are bugfixes needed by our organization. The fixes were merged in Debezium 3, but they are needed in Debezium `2.7` because our organization can't upgrade past Java 11 soon enough to get the fix from Debezium 3, which requires Java 17/21.

This change backports the commits related to [DBZ-8194](https://issues.redhat.com/browse/DBZ-8194) and [DBZ-8340](https://issues.redhat.com/browse/DBZ-8340) to version `0.31.x`, which the Debezium team has agreed to adopt in `2.7.3.Final` after merge: [Zulip](https://debezium.zulipchat.com/#narrow/channel/348104-community-mysql-mariadb/topic/Incremental.20snapshots.20leads.20to.20streaming.201.20day.20older.20data/near/479858059)

[DBZ-8387](https://issues.redhat.com/browse/DBZ-8387)