### PR TITLE
debezium/dbz#2266 Prevent keepalive reconnect loop while binlog position is being resolved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+- Prevent the keepalive thread from tearing down a connection that is still waiting for its
+  first event (debezium/dbz#2266): with heartbeats enabled, the event-staleness check now
+  applies only once the current connection has started streaming. Until then the socket is
+  probed with a ping, so a position lookup that takes longer than `keepAliveInterval`
+  (e.g. GTID auto-positioning over a large number of retained binlog files) no longer
+  causes a permanent reconnect loop that never consumes any events.
 - Fix TLS 1.3 KeyUpdate causing "Connection reset by peer" on high-throughput connections
   under Java 17+ (debezium/dbz#2213):
   - `DefaultSSLSocketFactory` now pins the SSL socket to the requested protocol version via

--- a/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
+++ b/src/main/java/com/github/shyiko/mysql/binlog/BinaryLogClient.java
@@ -166,6 +166,8 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
 
     private long heartbeatInterval;
     private volatile long eventLastSeen;
+    // visible for testing
+    volatile boolean eventSeenSinceConnect;
 
     private long connectTimeout = TimeUnit.SECONDS.toMillis(3);
 
@@ -656,6 +658,7 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
                 setupConnection();
                 gtid = null;
                 tx = false;
+                eventSeenSinceConnect = false;
                 requestBinaryLogStream();
             } catch (IOException e) {
                 disconnectChannel();
@@ -923,6 +926,32 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
         ensureEventDataDeserializer(EventType.MARIADB_GTID_LIST, MariadbGtidListEventDataDeserializer.class);
     }
 
+    /**
+     * Decides whether the keepalive thread should consider the connection lost and force a reconnect.
+     * <p>
+     * The event-staleness check is only applied to an established stream. After
+     * COM_BINLOG_DUMP(_GTID) the server may spend an arbitrarily long time locating the requested
+     * position before it sends the first event or heartbeat (e.g. GTID auto-positioning scans the
+     * Previous_gtids header of every binlog file from the newest backward to the resume point).
+     * Declaring the connection lost during that phase would tear it down mid-search and restart the
+     * search from scratch on reconnect, so a client that is far enough behind would loop forever
+     * without ever receiving an event (debezium/dbz#2266). Until the first event of the current
+     * connection is seen, the socket is probed with a ping instead — it fails only if the
+     * connection is actually broken.
+     */
+    // visible for testing
+    boolean isConnectionLost() {
+        if (heartbeatInterval > 0 && eventSeenSinceConnect) {
+            return System.currentTimeMillis() - eventLastSeen > keepAliveInterval;
+        }
+        try {
+            channel.write(new PingCommand());
+            return false;
+        } catch (IOException e) {
+            return true;
+        }
+    }
+
     private void spawnKeepAliveThread() {
         final ExecutorService threadExecutor =
             Executors.newSingleThreadExecutor(new ThreadFactory() {
@@ -947,17 +976,7 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
                             logger.info("threadExecutor is shut down, terminating keepalive thread");
                             return;
                         }
-                        boolean connectionLost = false;
-                        if (heartbeatInterval > 0) {
-                            connectionLost = System.currentTimeMillis() - eventLastSeen > keepAliveInterval;
-                        } else {
-                            try {
-                                channel.write(new PingCommand());
-                            } catch (IOException e) {
-                                connectionLost = true;
-                            }
-                        }
-                        if (connectionLost) {
+                        if (isConnectionLost()) {
                             logger.info("Keepalive: Trying to restore lost connection to " + hostname + ":" + port);
                             try {
                                 terminateConnect(useNonGracefulDisconnect);
@@ -1158,6 +1177,7 @@ public class BinaryLogClient implements BinaryLogClientMXBean {
                 }
                 if (isConnected()) {
                     eventLastSeen = System.currentTimeMillis();
+                    eventSeenSinceConnect = true;
                     updateGtidSet(event);
                     notifyEventListeners(event);
                     updateClientBinlogFilenameAndPosition(event);

--- a/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientTest.java
+++ b/src/test/java/com/github/shyiko/mysql/binlog/BinaryLogClientTest.java
@@ -423,6 +423,110 @@ public class BinaryLogClientTest {
         serverSocket.close();
     }
 
+    /**
+     * Builds a PacketChannel over a stub socket. When {@code writable} is false every write
+     * fails with an IOException, emulating a broken connection.
+     */
+    private static PacketChannel stubChannel(final boolean writable) throws IOException {
+        return new PacketChannel(new Socket() {
+            @Override
+            public InputStream getInputStream() throws IOException {
+                return new InputStream() {
+                    @Override
+                    public int read() throws IOException {
+                        return -1;
+                    }
+                };
+            }
+
+            @Override
+            public OutputStream getOutputStream() throws IOException {
+                return new OutputStream() {
+                    @Override
+                    public void write(int b) throws IOException {
+                        if (!writable) {
+                            throw new IOException("test: broken pipe");
+                        }
+                    }
+                };
+            }
+        });
+    }
+
+    /**
+     * With heartbeats enabled, the keepalive thread must not declare a connection lost before the
+     * first event of that connection has arrived, no matter how stale eventLastSeen is: after
+     * COM_BINLOG_DUMP(_GTID) the server may take longer than keepAliveInterval to locate the
+     * requested position (e.g. GTID auto-positioning over a large number of binlog files), during
+     * which it sends neither events nor heartbeats. Tearing the connection down then restarts the
+     * position search from scratch, so the client would reconnect forever without ever streaming
+     * (debezium/dbz#2266).
+     */
+    @Test
+    public void testKeepAliveToleratesSilenceWhileAwaitingFirstEvent() throws IOException {
+        BinaryLogClient client = new BinaryLogClient("localhost", 3306, "root", "mysql");
+        client.setHeartbeatInterval(80);
+        client.setKeepAliveInterval(100);
+        // eventSeenSinceConnect defaults to false and eventLastSeen to 0, i.e. arbitrarily stale
+        client.channel = stubChannel(true);
+        assertFalse(client.isConnectionLost(),
+            "a connection awaiting its first event must not be considered lost while its socket is writable");
+    }
+
+    /**
+     * A connection that is still awaiting its first event is probed with a ping, so a socket that
+     * is actually broken during the position-resolution phase is still detected as lost.
+     */
+    @Test
+    public void testKeepAliveDetectsBrokenSocketWhileAwaitingFirstEvent() throws IOException {
+        BinaryLogClient client = new BinaryLogClient("localhost", 3306, "root", "mysql");
+        client.setHeartbeatInterval(80);
+        client.setKeepAliveInterval(100);
+        client.channel = stubChannel(false);
+        assertTrue(client.isConnectionLost(),
+            "a broken socket must be detected even before the first event is received");
+    }
+
+    /**
+     * Once the first event of the current connection has been seen, the original behavior applies:
+     * with heartbeats enabled the connection is considered lost when no event has been received for
+     * more than keepAliveInterval.
+     */
+    @Test
+    public void testKeepAliveReconnectsWhenEstablishedStreamGoesSilent() throws IOException {
+        BinaryLogClient client = new BinaryLogClient("localhost", 3306, "root", "mysql");
+        client.setHeartbeatInterval(80);
+        client.channel = stubChannel(true);
+        client.eventSeenSinceConnect = true;
+        // eventLastSeen is 0, so the stream is stale for any realistic interval...
+        client.setKeepAliveInterval(1);
+        assertTrue(client.isConnectionLost(),
+            "an established stream that went silent for longer than keepAliveInterval must reconnect");
+        // ...but not when the interval exceeds the time elapsed since epoch
+        client.setKeepAliveInterval(Long.MAX_VALUE);
+        assertFalse(client.isConnectionLost(),
+            "an established stream within keepAliveInterval must not reconnect");
+    }
+
+    /**
+     * With heartbeats disabled the keepalive has always probed the connection with a ping and
+     * never consulted event staleness; that behavior must be preserved by the extracted
+     * decision logic.
+     */
+    @Test
+    public void testKeepAlivePingsWhenHeartbeatsDisabled() throws IOException {
+        BinaryLogClient client = new BinaryLogClient("localhost", 3306, "root", "mysql");
+        // heartbeatInterval stays 0; eventLastSeen is 0, i.e. stale for any interval
+        client.setKeepAliveInterval(1);
+        client.eventSeenSinceConnect = true;
+        client.channel = stubChannel(true);
+        assertFalse(client.isConnectionLost(),
+            "with heartbeats disabled a writable socket must not be considered lost, however stale eventLastSeen is");
+        client.channel = stubChannel(false);
+        assertTrue(client.isConnectionLost(),
+            "with heartbeats disabled a broken socket must be considered lost");
+    }
+
     /*
     @Test
     public void testDeadlockyCode() throws IOException, InterruptedException {


### PR DESCRIPTION
Closes https://github.com/debezium/dbz/issues/2266

## Problem

A connector resuming far behind the source (large binlog retention, ~1,000+ files in the reported incident) enters a permanent keepalive reconnect loop and consumes zero events: `NumberOfDisconnects` climbs ~1/minute, the committed position stays frozen, there are no socket errors, and the Kafka Connect task stays RUNNING so orchestrator auto-restart never fires.

## Root cause

After `COM_BINLOG_DUMP_GTID` the server locates the start file by scanning the `Previous_gtids` header of each binlog file from the newest backward to the resume point (MySQL refman §19.1.3.3, "GTID Auto-Positioning"). Far enough behind, that scan exceeds `keepAliveInterval` (~3 minutes vs. the 60 s default in the reported incident), and during it the server sends neither events nor heartbeats — the dump thread has not entered its send loop, so the requested `master_heartbeat_period` has no effect yet.

The keepalive staleness check (`now - eventLastSeen > keepAliveInterval`, taken whenever `heartbeatInterval > 0`, which Debezium always sets) knows nothing about this phase: `eventLastSeen` is only written when an event is deserialized and is never reset on (re)connect, so while awaiting the first event it holds either 0 or the previous connection's last-event timestamp — both arbitrarily stale. The first keepalive tick after connecting therefore tears the connection down mid-scan and reconnects, restarting the scan from scratch. The loop never converges.

## Fix

Credit to @Naros for the fix direction: the keepalive timer should effectively start at the first event rather than at connect time. Concretely:

- `eventSeenSinceConnect` tracks whether the current connection has delivered its first event (reset in `connect()`, set in `listenForEventPackets()`).
- The event-staleness check applies only to an established stream. Until the first event arrives, keepalive probes the socket by writing a ping — the same mechanism it has always used when heartbeats are disabled — which fails only if the connection is actually broken.

So a healthy connection still resolving the requested position is left alone no matter how long the scan takes; a socket that actually dies during the scan is still detected and reconnected; established-stream behavior is unchanged (silence longer than `keepAliveInterval` still forces a reconnect). Once the dump send loop starts, ROTATE/FORMAT_DESCRIPTION arrive immediately even on an idle server, so the flag flips as soon as streaming begins and heartbeats feed the staleness check from then on.

The keepalive decision is extracted into a package-private `isConnectionLost()` for unit-testability.

An alternative considered was a grace period after connect: any fixed grace just moves the threshold, since scan time grows with binlog retention, while gating on the first event handles it structurally without new configuration. If desired, a configurable cap on the awaiting-first-event exemption (forcing a reconnect after N × `keepAliveInterval` without a first event) composes cleanly on top of this change to also cover an alive-but-wedged server; happy to add it if the maintainers want the knob.

## Tests

Four new unit tests in `BinaryLogClientTest` (no live server needed; the keepalive decision is tested directly against stub channels):

- no teardown while awaiting the first event on a writable socket — fails without this fix;
- a broken socket is still detected while awaiting the first event;
- an established stream that goes silent longer than `keepAliveInterval` still reconnects;
- with heartbeats disabled the ping probe is used regardless of event staleness (legacy path preserved).

Full unit suite passes (`mvn test`: 109 tests, 0 failures). The originating scenario (Debezium 3.x on Aurora MySQL 3, GTID auto-position, ~1,000+ binlog files behind, default `connect.keep.alive.interval.ms`) was verified in production: with the stock client the connector reconnected every 60 s indefinitely with zero events; raising the keepalive interval above the scan time — the workaround this patch makes unnecessary — let it stream and drain the backlog.
